### PR TITLE
418 Teapot poor mans IPS

### DIFF
--- a/root/defaults/fail2ban/filter.d/nginx-http-418.conf
+++ b/root/defaults/fail2ban/filter.d/nginx-http-418.conf
@@ -1,0 +1,9 @@
+# fail2ban filter configuration for nginx
+# Track RFC2324
+# 418 I'm a teapot
+# Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot". The resulting entity body MAY be short and stout.
+
+[Definition]
+
+failregex = ^<HOST>.*"(GET|POST).*" (418) .*$
+ignoreregex =

--- a/root/defaults/jail.local
+++ b/root/defaults/jail.local
@@ -29,14 +29,6 @@ ignoreip = 127.0.0.1 172.16.0.0/12 192.168.0.0/16 10.0.0.0/8
 enabled = false
 
 
-[nginx-http-auth]
-
-enabled  = false
-filter   = nginx-http-auth
-port     = http,https
-logpath  = /remotelog/nginx/error.log
-
-
 [nginx-badbots]
 
 enabled  = false
@@ -54,6 +46,24 @@ filter   = nginx-botsearch
 logpath  = /remotelog/nginx/access.log
 
 
+[nginx-http-418]
+
+enabled  = false
+port     = http,https
+filter   = nginx-http-418
+logpath  = /remotelog/nginx/access.log
+findtime = 3600
+maxretry = 10
+
+
+[nginx-http-auth]
+
+enabled  = false
+filter   = nginx-http-auth
+port     = http,https
+logpath  = /remotelog/nginx/error.log
+
+
 [nginx-deny]
 
 enabled  = false
@@ -68,13 +78,3 @@ enabled  = false
 port     = 8920
 filter   = emby-http-auth
 logpath  = /remotelog/emby/embyserver.txt
-
-
-[nginx-http-418]
-
-enabled  = false
-port     = http,https
-filter   = nginx-http-418
-logpath  = /remotelog/nginx/access.log
-findtime = 3600
-maxretry = 10

--- a/root/defaults/jail.local
+++ b/root/defaults/jail.local
@@ -68,3 +68,13 @@ enabled  = false
 port     = 8920
 filter   = emby-http-auth
 logpath  = /remotelog/emby/embyserver.txt
+
+
+[nginx-http-418]
+
+enabled  = false
+port     = http,https
+filter   = nginx-http-418
+logpath  = /remotelog/nginx/access.log
+findtime = 3600
+maxretry = 10


### PR DESCRIPTION
This puts in place the basic framework for implementing very basic Intrusion Protection.

The premise is simple, any time you can identify abuse and want it to be counted towards an IP ban send the user a 418, legitimate but weird, status code.

For example if you dont run wordpress or phpmyadmin then any call to either of these very common attack end points can be detected and count towards a block.

This wont achieve an awful lot but the cost is small and every little bit helps.